### PR TITLE
feat: support for multi dispatch

### DIFF
--- a/examples/playexample.rs
+++ b/examples/playexample.rs
@@ -1,0 +1,39 @@
+#![allow(dead_code)]
+#![allow(unused)]
+use penum::penum;
+
+#[penum]
+trait Trait2 {}
+
+#[penum]
+trait Trait {
+    fn go(&self) -> String;
+}
+
+impl Trait for i32 {
+    fn go(&self) -> String {
+        "todo!()".to_string()
+    }
+}
+
+impl Trait for usize {
+    fn go(&self) -> String {
+        "todo!()".to_string()
+    }
+}
+
+impl Trait2 for i32 {}
+impl Trait2 for usize {}
+
+#[penum( impl Trait for {usize, i32} )]
+enum Mine {
+    V1(i32),
+    V2(i32),
+    V3(usize, i32),
+}
+
+fn main() {
+    let m = Mine::V2(20);
+
+    let n = m.go();
+}

--- a/examples/userdispatch.rs
+++ b/examples/userdispatch.rs
@@ -81,7 +81,7 @@ impl AsRef<str> for Inner {
     }
 }
 
-#[penum(impl AsRef<str> for {String,Inner})]
+#[penum(_ where String: ^AsRef<str> )]
 enum Store {
     V0(Inner),
 

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -1,5 +1,5 @@
 pub use self::blueprint::Blueprint;
-pub use self::blueprint::Blueprints;
+pub use self::blueprint::BlueprintsMap;
 pub use self::sig::VariantSig;
 
 mod blueprint;

--- a/src/factory/pattern.rs
+++ b/src/factory/pattern.rs
@@ -9,6 +9,7 @@ use quote::ToTokens;
 use crate::{
     dispatch::{Blueprint, Blueprints},
     error::Diagnostic,
+    penum::Stringify,
     utils::UniqueHashId,
 };
 
@@ -177,11 +178,23 @@ impl PenumExpr {
                         }
                     }
                 }
+
                 if blueprints.is_empty() {
                     return None;
                 }
 
+                // If pred_ty is concrete, use trait bound as a key
+
+                // let pat_ty_string = pred_ty.bounded_ty.get_string();
+                // let is_generic = pat_ty_string.to_uppercase().eq(&pat_ty_string);
+
                 let ty = UniqueHashId(pred_ty.bounded_ty.clone());
+                // if is_generic {
+                //     UniqueHashId(pred_ty.bounded_ty.clone())
+                // } else {
+                //     // blueprints
+                //     let concrete = pred_ty.bounds.last();
+                // };
 
                 if let Some(entry) = polymap.get_mut(&ty) {
                     entry.append(&mut blueprints);

--- a/src/factory/pattern/parse.rs
+++ b/src/factory/pattern/parse.rs
@@ -2,7 +2,6 @@ use proc_macro2::TokenStream;
 use syn::{
     braced, parenthesized,
     parse::{Parse, ParseStream},
-    spanned::Spanned,
     token, Field, Ident, LitInt, LitStr, Token, Type,
 };
 
@@ -23,30 +22,31 @@ impl Parse for ImplExpr {
             impl_token: input.parse()?,
             trait_bound: input.parse()?,
             for_token: input.parse()?,
-            tys: {
-                if input.peek(token::Brace) {
-                    let content;
-                    let _ = braced!(content in input);
-                    let mut tys = vec![];
+            /// FIXME: There's probably a better way of doing this.
+            /// Check Puncuated.
+            tys: if input.peek(token::Brace) {
+                let content;
+                let _ = braced!(content in input);
+                let mut tys = vec![];
 
-                    loop {
-                        if content.is_empty() {
-                            break;
-                        }
-
-                        let ty: Type = content.parse()?;
-                        tys.push(ty);
-
-                        if !content.peek(token::Comma) {
-                            break;
-                        } else {
-                            let _: token::Comma = content.parse()?;
-                        }
+                loop {
+                    if content.is_empty() {
+                        break;
                     }
-                    tys
-                } else {
-                    vec![input.parse()?]
+
+                    let ty: Type = content.parse()?;
+                    tys.push(ty);
+
+                    if content.peek(token::Comma) {
+                        let _: token::Comma = content.parse()?;
+                    } else {
+                        break;
+                    }
                 }
+
+                tys
+            } else {
+                vec![input.parse()?]
             },
         })
     }

--- a/src/penum.rs
+++ b/src/penum.rs
@@ -72,6 +72,8 @@ impl Penum<Disassembled> {
         let enum_ident = &self.subject.ident;
         let error = &mut self.error;
 
+        println!("{}", self.expr.pattern_to_string());
+
         if !variants.is_empty() {
             // The point is that as we check for equality, we also do
             // impl assertions by extending the `subjects` where clause.
@@ -321,7 +323,7 @@ impl Penum<Disassembled> {
                             #(#assoc_methods)*
                         }
                     );
-
+                    println!("{}", implementation.to_token_stream());
                     self.impls.push(implementation);
                 });
             }
@@ -359,6 +361,7 @@ impl Penum<Assembled> {
                 let impl_items = self.impls;
                 let output = quote::quote!(#enum_item #(#impl_items)*);
 
+                println!("{}", output);
                 output
             })
             .into()

--- a/tests/test-traits.rs
+++ b/tests/test-traits.rs
@@ -1,0 +1,80 @@
+#![allow(dead_code)]
+extern crate penum;
+use penum::penum;
+
+// #[penum]
+// pub trait TraitBlank {}
+
+// #[penum]
+// pub trait TraitWithGenericT<T> {}
+
+// #[penum]
+// pub trait TraitWithAssocType {
+//     type Type;
+// }
+
+// #[penum]
+// pub trait TraitWithAssocMethodVoid {
+//     fn method(&self);
+// }
+
+// #[penum]
+// pub trait TraitWithAssocMethodSelf {
+//     fn method(&self) -> Self;
+// }
+
+// #[penum]
+// pub trait TraitWithAssocMethodString {
+//     fn method(&self) -> String;
+// }
+
+// #[penum]
+// pub trait TraitWithGenericTAssocMethodT<T> {
+//     fn method(&self) -> T;
+// }
+
+// // -------------------------------
+
+// #[penum]
+// pub trait TraitAssocReturn {
+//     type Return;
+
+//     fn method(&self) -> &Self::Return;
+// }
+
+// #[penum]
+// pub trait TraitComposed<T>: TraitAssocReturn<Return = T> {
+//     fn input(&self, input: T) -> Self::Return;
+// }
+
+// impl TraitAssocReturn for String {
+//     type Return = Self;
+
+//     fn method(&self) -> &Self::Return {
+//         self
+//     }
+// }
+
+// impl<T> TraitComposed<T> for String
+// where
+//     Self: TraitAssocReturn<Return = T>,
+// {
+//     fn input(&self, input: T) -> Self::Return {
+//         input
+//     }
+// }
+
+// #[penum( impl TraitComposed<String> for String )]
+// #[penum( impl ^AsRef<str> for String )]
+#[penum( impl AsRef<str> for String )]
+enum Abc {
+    V0(String),
+    V1(i32, String),
+    V2,
+}
+
+fn main() {
+    let s = Abc::V0("hello".to_string());
+
+    let s = s.as_ref();
+}

--- a/tests/test-traits.rs
+++ b/tests/test-traits.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![allow(unused)]
 extern crate penum;
 use penum::penum;
 

--- a/traits/src/main.rs
+++ b/traits/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::all)]
+#![allow(named_arguments_used_positionally)]
 use ::rustfmt::{format_input, Input};
 use regex::Regex;
 use scraper::{Html, Selector};


### PR DESCRIPTION
Support for `impl Trait for {Type,*}` syntax.

It's identical to:
```rust
#[penum(_ where Type: ^Trait,*)]
```

Note that we might not have support for these yet:
```rust
#[penum((T) | (U, ..) where T: ^Trait, U: ^Trait )]
```

I think.....