### PR TITLE
feat: support for empty trait binding

### DIFF
--- a/examples/playexample.rs
+++ b/examples/playexample.rs
@@ -64,20 +64,25 @@ enum Mine4 {
     V3(usize, i32),
 }
 
-#[penum( (T) | (T, U) where T: ^Trait, T: ^Trait2)]
+#[penum]
+trait Cool {
+    type Target;
+    fn mine(&self, value: Self::Target) -> &i32;
+}
+
+impl Cool for i32 {
+    type Target = String;
+    fn mine(&self, value: String) -> &i32 {
+        self
+    }
+}
+
+#[penum( _ where i32: ^Cool )]
 enum Mine5 {
     V1(i32),
     V2(i32),
     V3(i32, i32),
 }
-// impl Trait2 for Mine4 {
-//     fn go2(&self) -> String {
-//         match self {
-//             Mine4::V3(val, ..) => val.go2(),
-//             _ => "".to_string(),
-//         }
-//     }
-// }
 
 fn main() {
     let m = Mine::V2(20);

--- a/src/factory/clause.rs
+++ b/src/factory/clause.rs
@@ -1,8 +1,7 @@
-use std::borrow::Borrow;
-
 use proc_macro2::Ident;
+use quote::format_ident;
 use syn::{
-    punctuated::Punctuated, token, BoundLifetimes, Lifetime, Path, Token, TraitBoundModifier, Type,
+    punctuated::Punctuated, token, BoundLifetimes, Lifetime, Token, TraitBoundModifier, Type,
 };
 
 mod parse;
@@ -48,7 +47,7 @@ pub struct TraitBound {
     pub dispatch: Option<Token![^]>,
     pub modifier: TraitBoundModifier,
     pub lifetimes: Option<BoundLifetimes>,
-    pub path: Path,
+    pub ty: Type,
 }
 
 impl TypeParamBound {
@@ -62,12 +61,16 @@ impl TypeParamBound {
 }
 
 impl TraitBound {
-    pub fn get_ident(&self) -> &Ident {
-        self.path
-            .segments
-            .last()
-            .expect("dispatchable trait to have a name")
-            .ident
-            .borrow()
+    pub fn get_ident(&self) -> Ident {
+        if let Type::Path(p) = &self.ty {
+            p.path
+                .segments
+                .last()
+                .expect("dispatchable trait to have a name")
+                .ident
+                .clone()
+        } else {
+            format_ident!("{}", "omg")
+        }
     }
 }

--- a/src/factory/clause/to_tokens.rs
+++ b/src/factory/clause/to_tokens.rs
@@ -52,7 +52,7 @@ impl ToTokens for TraitBound {
         let to_tokens = |tokens: &mut TokenStream| {
             self.modifier.to_tokens(tokens);
             self.lifetimes.to_tokens(tokens);
-            self.path.to_tokens(tokens);
+            self.ty.to_tokens(tokens);
         };
         match &self.paren_token {
             Some(paren) => paren.surround(tokens, to_tokens),

--- a/src/factory/pattern.rs
+++ b/src/factory/pattern.rs
@@ -196,18 +196,7 @@ impl PenumExpr {
                     return None;
                 }
 
-                // If pred_ty is concrete, use trait bound as a key
-
-                // let pat_ty_string = pred_ty.bounded_ty.get_string();
-                // let is_generic = pat_ty_string.to_uppercase().eq(&pat_ty_string);
-
                 let ty = UniqueHashId(pred_ty.bounded_ty.clone());
-                // if is_generic {
-                //     UniqueHashId(pred_ty.bounded_ty.clone())
-                // } else {
-                //     // blueprints
-                //     let concrete = pred_ty.bounds.last();
-                // };
 
                 if let Some(entry) = polymap.get_mut(&ty) {
                     entry.append(&mut blueprints);

--- a/src/factory/subject.rs
+++ b/src/factory/subject.rs
@@ -26,7 +26,7 @@ impl Subject {
         &self.data.variants
     }
 
-    pub fn get_comparable_fields(&self) -> impl Iterator<Item = (&Ident, Comparable<Fields>)> {
+    pub fn comparable_fields_iter(&self) -> impl Iterator<Item = (&Ident, Comparable<Fields>)> {
         self.get_variants()
             .iter()
             .map(|variant| (&variant.ident, Comparable::from(&variant.fields)))

--- a/src/penum.rs
+++ b/src/penum.rs
@@ -102,7 +102,7 @@ impl Penum<Disassembled> {
             //    - Failure: add a "no_match_found" error and continue
             //      to next variant.
             // 2. Validate each parameter    ...continue... (INNER)
-            for (variant_ident, comp_item) in self.subject.get_comparable_fields() {
+            for (variant_ident, comp_item) in self.subject.comparable_fields_iter() {
                 // FIXME: This only affects concrete types.. but
                 //  `.compare(..)` should return a list of matches
                 //  instead of just the first match it finds.
@@ -172,7 +172,11 @@ impl Penum<Disassembled> {
                                 arity,
                             );
 
-                            blueprints.find_and_attach(&item_ty_unique, &variant_sig);
+                            blueprints.find_and_attach(
+                                &item_ty_unique,
+                                &variant_sig,
+                                Some(&item_ty_unique),
+                            );
                         }
                         self.types
                             .polymap_insert(item_ty_unique.clone(), item_ty_unique);
@@ -210,9 +214,6 @@ impl Penum<Disassembled> {
                         self.types
                             .polymap_insert(unique_impl_id.clone().into(), item_ty_unique);
                     } else {
-                        // NOTE: This string only contains the Ident, so any generic parameters will
-                        // be discarded.
-                        let pat_ty_string = pat_field.ty.get_string();
                         let pat_ty_unique = pat_field.ty.get_unique_id();
 
                         let variant_sig = VariantSig::new(
@@ -235,7 +236,11 @@ impl Penum<Disassembled> {
                             if item_ty_unique.eq(&pat_ty_unique) {
                                 // Continuing means that we wont add T bounds to polymap
                                 if let Some(blueprints) = maybe_blueprint_map.as_mut() {
-                                    blueprints.find_and_attach(&pat_ty_unique, &variant_sig);
+                                    blueprints.find_and_attach(
+                                        &pat_ty_unique,
+                                        &variant_sig,
+                                        Some(&item_ty_unique),
+                                    );
                                 };
 
                                 self.types
@@ -243,7 +248,11 @@ impl Penum<Disassembled> {
                             } else {
                                 if let Some(blueprints) = maybe_blueprint_map.as_mut() {
                                     for ty_unique in [&pat_ty_unique, &item_ty_unique] {
-                                        blueprints.find_and_attach(ty_unique, &variant_sig);
+                                        blueprints.find_and_attach(
+                                            ty_unique,
+                                            &variant_sig,
+                                            Some(&item_ty_unique),
+                                        );
                                     }
                                 };
 
@@ -256,7 +265,11 @@ impl Penum<Disassembled> {
                         } else if pat_field.ty.is_placeholder() {
                             // Make sure we map the concrete type instead of the pat_ty
                             if let Some(blueprints) = maybe_blueprint_map.as_mut() {
-                                blueprints.find_and_attach(&item_ty_unique, &variant_sig);
+                                blueprints.find_and_attach(
+                                    &item_ty_unique,
+                                    &variant_sig,
+                                    Some(&item_ty_unique),
+                                );
                             }
                             self.types
                                 .polymap_insert(item_ty_unique.clone(), item_ty_unique);
@@ -265,7 +278,11 @@ impl Penum<Disassembled> {
                         } else if item_ty_unique.eq(&pat_ty_unique) {
                             // 3. Dispachable list
                             if let Some(blueprints) = maybe_blueprint_map.as_mut() {
-                                blueprints.find_and_attach(&item_ty_unique, &variant_sig);
+                                blueprints.find_and_attach(
+                                    &item_ty_unique,
+                                    &variant_sig,
+                                    Some(&item_ty_unique),
+                                );
                             }
 
                             self.types.polymap_insert(
@@ -275,6 +292,9 @@ impl Penum<Disassembled> {
                         } else {
                             // TODO: Refactor into TypeId instead.
                             let item_ty_string = field_item.ty.get_string();
+                            // NOTE: This string only contains the Ident, so any generic parameters will
+                            // be discarded.
+                            let pat_ty_string = pat_field.ty.get_string();
 
                             self.error.extend_spanned(
                                 &field_item.ty,

--- a/tests/test-dispatch-empty_trait_bindings.rs
+++ b/tests/test-dispatch-empty_trait_bindings.rs
@@ -1,0 +1,33 @@
+#![allow(dead_code)]
+#![allow(unused_variables)]
+#![allow(unreachable_patterns)]
+extern crate penum;
+use penum::penum;
+
+#[penum]
+trait Cool {
+    type Target;
+    fn mine(&self, value: Self::Target) -> &i32;
+}
+
+impl Cool for i32 {
+    type Target = String;
+    fn mine(&self, value: String) -> &i32 {
+        self
+    }
+}
+
+#[penum( _ where i32: ^Cool )]
+enum Mine5 {
+    V1(i32),
+    V2(i32),
+    V3(i32, i32),
+}
+
+fn main() {
+    let m = Mine5::V1(10);
+
+    let s = m.mine("wewe".to_string());
+
+    assert_eq!(&10, s);
+}


### PR DESCRIPTION
This PR will now add support for empty trait bindings in dispatch context.

```rust
#[penum]
trait Cool {
    type Target;
    fn mine(&self, value: Self::Target) -> &i32;
}

impl Cool for i32 {
    type Target = String;
    fn mine(&self, value: String) -> &i32 {
        self
    }
}

#[penum( (T) | (T, ..) where T: ^Cool)]
enum Mine5 {
    V1(i32),
    V2(i32),
    V3(i32, i32),
}
```

```rust
enum Mine5
where
    i32: Cool,
{
    V1(i32),
    V2(i32),
    V3(i32, i32),
}
impl Cool for Mine5 {
    type Target = <i32 as Cool>::Target;
    fn mine(&self, value: Self::Target) -> &i32 {
        match self {
            Mine5::V1(val) => val.mine(value),
            Mine5::V2(val) => val.mine(value),
            Mine5::V3(val, ..) => val.mine(value),
            _ => &0,
        }
    }
}
```